### PR TITLE
Fix click event handler so it works under firefox

### DIFF
--- a/notification.js
+++ b/notification.js
@@ -7,7 +7,7 @@ Template.notification.helpers({
 });
 
 Template.notification.events = {
-    'click': function () {
+    'click': function (event) {
         if (this.userCloseable || this.expires < new Date()) {
             // must the user click the close button?
             if (!this.clickBodyToClose && 0 > event.target.className.indexOf('closeButton')) {


### PR DESCRIPTION
event isn't a global object in firefox like it is in IE and Webkit browsers.  Easy fix.

Details are here: http://stackoverflow.com/questions/20522887/referenceerror-event-is-not-defined-error-in-firefox