### PR TITLE
Add callback on timeout: onExpires

### DIFF
--- a/notifications.js
+++ b/notifications.js
@@ -37,7 +37,7 @@ var constructor = (function() {
         notification.userCloseable = options.userCloseable;
         notification.clickBodyToClose = options.clickBodyToClose;
         notification.closed = options.closed;
-        notification.onRemoved = options.onRemoved;
+        notification.onExpires = options.onExpires;
 
         if (options.timeout) {
             notification.expires = new Date().getTime() + options.timeout;
@@ -165,14 +165,14 @@ var constructor = (function() {
 
         if (firstExpiration) {
             this._notificationTimeout = Meteor.setTimeout(function () {
-                // queue up the onRemoved
+                // queue up the onExpires
                 var needCallback = _ .filter(self._getNotificationsCollection().find({expires: {$lte: firstExpiration}}).fetch(),
-                                            function(notification) { return notification.onRemoved != undefined; }
+                                            function(notification) { return notification.onExpires != undefined; }
                                         );
                 if(needCallback.length > 0) {
                     Meteor.setTimeout(function () {
                         _.each(needCallback, function (notification) {
-                            if (notification.onRemoved) notification.onRemoved(notification); // check is redundant
+                            if (notification.onExpires) notification.onExpires(notification); // check is redundant
                         });
                     }, 500);
                 }


### PR DESCRIPTION
Implements additional callback on timeout.
UseCase: An manual action M (e.g. Save) is followed by an action A (e.g. Navigate away), and you want to show the result of M (Saved completed successfully)  in a notification before proceeding to perform the automated action A. 